### PR TITLE
Simplify native systemtest makefiles

### DIFF
--- a/openjdk.test.jck/build.xml
+++ b/openjdk.test.jck/build.xml
@@ -117,7 +117,7 @@ limitations under the License.
 	
 	<target name="setup-native-build-command">
 		<echo message="building natives for java_platform ${java_platform}"/>
-		<property name="openjdk_test_jck_native_build_command" value='${setup_windows_build_env}make build -f ${jck_makefile_dir}/makefile SRCDIR=${jck_runtimes_src_dir} PLATFORM=${java_platform} JAVA_HOME=${TEST_JDK_HOME} OUTDIR=${out_dir}'/>
+		<property name="openjdk_test_jck_native_build_command" value='${setup_windows_build_env}make build -f ${jck_makefile_dir}/makefile SRCDIR=${jck_runtimes_src_dir} JAVA_HOME=${TEST_JDK_HOME} OUTDIR=${out_dir}'/>
 		<tempfile property="openjdk_test_jck_native_build_command_file" destDir="${java.io.tmpdir}" prefix="openjdk.build.command."/>
 	</target>
 

--- a/openjdk.test.jck/src/native/makefile
+++ b/openjdk.test.jck/src/native/makefile
@@ -11,26 +11,47 @@
 # limitations under the License.
 
 # This makefile compiles the native test cases in the JCK.
-# Usage: make build [PLATFORM=name] [SRCDIR=path] [OUTDIR=path] 
+# Usage: make build [SRCDIR=path] [OUTDIR=path] 
 # Example:
-# make build PLATFORM=win_x86-32   SRCDIR=C:\jck\jck8b\JCK-runtime-8b OUTDIR=C:\jck\jck8b\natives
-# make build PLATFORM=linux_x86-32 SRCDIR=/jck/jck8b/JCK-runtime-8b OUTDIR=/jck/jck8b/natives
-# make clean PLATFORM=win_x86-32   OUTDIR=C:\jck\jck8b\natives
-# make clean PLATFORM=linux_x86-32 OUTDIR=/jck/jck8b/natives
+# make build SRCDIR=C:\jck\jck8b\JCK-runtime-8b OUTDIR=C:\jck\jck8b\natives
+# make build SRCDIR=/jck/jck8b/JCK-runtime-8b OUTDIR=/jck/jck8b/natives
+# make clean OUTDIR=C:\jck\jck8b\natives
+# make clean OUTDIR=/jck/jck8b/natives
 
 # This makefile needs to run jar.
 # If JAVA_HOME is set, use that one.
 # If JAVA_HOME is not set, look for jar on the PATH.
 
-WIN=0
-ifeq ($(PLATFORM),win_x86-32)
-	DESTDIR=$(OUTDIR)\$(PLATFORM)
-	WIN=1
+###
+# Figure out current platform
+###
+OS:=$(shell uname -s | tr "[:upper:]" "[:lower:]")
+
+ifneq (,$(findstring cygwin,$(OS)))
+	OS:=win
 endif
 
-ifeq ($(PLATFORM),win_x86-64)
-	DESTDIR=$(OUTDIR)\$(PLATFORM)
-    WIN=1
+ifneq (,$(findstring darwin,$(OS)))
+	OS:=osx
+endif
+
+ifeq ($(OS),os/390)
+	OS:=zos
+endif 
+
+ifneq (,$(findstring win,$(OS)))
+	OS:=win
+endif
+
+$(info OS is $(OS))
+
+ifeq ($(OS),win)
+	DESTDIR=$(OUTDIR)\$(OS)
+endif
+
+# AIX requires bitmode value to be passed into compilar flags
+ifeq ($(OS),aix)
+	BitMode:=$(shell getconf KERNEL_BITMODE)
 endif
 
 # Environment variable OSTYPE is set to cygwin if running under cygwin.
@@ -47,7 +68,7 @@ endif
 
 D:=/
 
-ifeq ($(WIN),1)
+ifeq ($(OS),win)
    ifeq (0,$(CYGWIN))
 	   D:=\\
    endif
@@ -57,7 +78,7 @@ ifneq (,$(JAVA_HOME))
   JAR:=$(JAVA_HOME)$(D)bin$(D)jar
   $(warning JAVA_HOME set to $(JAVA_HOME). Using $(JAR) to create jar files)
 else
-  ifneq (,$(findstring win,$(PLATFORM)))
+  ifneq (,$(findstring win,$(OS)))
     JAR:=$(dir $(firstword $(shell where jar.exe 2>nul)))
   else  # Unix
     JAR:=$(dir $(firstword $(shell which jar 2>/dev/null)))
@@ -71,16 +92,16 @@ endif
 
 # Following defaults set for Unix environment. For Windows platform following variables are overriden
 LIBPREF=lib
-ifneq (,$(findstring aix,$(PLATFORM)))
+ifneq (,$(findstring aix,$(OS)))
 	LIBEXT=a
 else
-ifneq (,$(findstring osx,$(PLATFORM)))
+ifneq (,$(findstring osx,$(OS)))
 	LIBEXT=dylib
 else
 	LIBEXT=so
 endif
 endif
-ifneq (,$(findstring hp,$(PLATFORM)))
+ifneq (,$(findstring hp,$(OS)))
 	OFLAG=
 	BUILDD=
 	OFLAGTEMP=ld -b -o
@@ -99,16 +120,18 @@ endif
 MKDIR=mkdir -p
 CLEANDIR=rm -rf
 CLEANFILE=rm -rf
-FULLOUTDIR=$(OUTDIR)$(D)$(PLATFORM)$(D)
+FULLOUTDIR=$(OUTDIR)$(D)$(OS)$(D)
 COPYDIR=cp -r
 AND_IF_SUCCESSFUL=&&
 export AND_IF_SUCCESSFUL
 
 VPATH=$(SRCDIR)$(D)src$(D)share$(D)lib$(D)jni$(D):$(SRCDIR)$(D)src$(D)share$(D)lib$(D)atr$(D):$(SRCDIR)$(D)src$(D)share$(D)lib$(D)jvmti$(D):$(SRCDIR)$(D)tests$(D)api$(D)javax_management$(D)loading$(D)data$(D)archives$(D)src$(D)C$(D):$(SRCDIR)$(D)src
 JMX_DATA_PATH=$(SRCDIR)$(D)tests$(D)api$(D)javax_management$(D)loading$(D)data
-SOLARIS_PATH=$(SRCDIR)$(D)src$(D)share$(D)lib$(D)jni$(D)include$(D)solaris
-LINUX_PATH=$(SRCDIR)$(D)src$(D)share$(D)lib$(D)jni$(D)include$(D)linux
 JNI_INCLUDE_PATH=$(SRCDIR)$(D)src$(D)share$(D)lib$(D)jni$(D)include
+SOLARIS_PATH=$(JNI_INCLUDE_PATH)$(D)solaris
+LINUX_PATH=$(JNI_INCLUDE_PATH)$(D)linux
+UNIX_PATH=$(JNI_INCLUDE_PATH)$(D)unix
+OSX_PATH=$(JNI_INCLUDE_PATH)$(D)amd64
 JVMTI_INCLUDE_PATH=$(SRCDIR)$(D)src$(D)share$(D)lib$(D)jvmti$(D)include
 SRC_PATH=$(SRCDIR)/src
 
@@ -116,100 +139,29 @@ SRC_PATH=$(SRCDIR)/src
 # Prior to jck10 the unix include files are in src/share/lib/jni/include/solaris
 # From jck10 the unix include files are in src/share/lib/jni/include/linux
 
-ifeq ($(PLATFORM),linux_x86-32)
-	CC=gcc
-	CFLAGS=-fPIC -m32 -I$(SOLARIS_PATH) -I$(LINUX_PATH) -I$(SRC_PATH)
-	LDFLAGS=-shared 
-endif	
+CC=gcc
+CFLAGS=-fPIC -I$(SOLARIS_PATH) -I$(LINUX_PATH) -I$(SRC_PATH)
+LDFLAGS=-shared 
 
-ifeq ($(PLATFORM),linux_ppc-32)
+ifeq ($(OS),osx)
 	CC=gcc
-	CFLAGS=-fPIC -m32 -I$(SOLARIS_PATH) -I$(LINUX_PATH) -I$(SRC_PATH)
-	LDFLAGS=-shared 
-endif	
-
-ifeq ($(PLATFORM),linux_ppc-64)
-	CC=gcc
-	CFLAGS=-fPIC -D_LP64 -m64 -I$(SOLARIS_PATH) -I$(LINUX_PATH) -I$(SRC_PATH)
+	CFLAGS=-fPIC -I$(OSX_PATH) -I$(SRC_PATH)
 	LDFLAGS=-shared
 endif
 
-ifeq ($(PLATFORM),linux_ppcle-64)
-	CC=gcc
-	CFLAGS=-fPIC -D_LP64 -m64 -I$(SOLARIS_PATH) -I$(LINUX_PATH) -I$(SRC_PATH)
-	LDFLAGS=-shared
-endif
-
-ifeq ($(PLATFORM),linux_x86-64)
-	CC=gcc
-	CFLAGS=-fPIC -D_LP64 -m64 -I$(SOLARIS_PATH) -I$(LINUX_PATH) -I$(SRC_PATH)
-	LDFLAGS=-shared
-endif
-
-ifeq ($(PLATFORM),osx_x86-64)
-	CC=gcc
-	CFLAGS=-fPIC -D_LP64 -m64 -I$(SRCDIR)/src/share/lib/jni/include/amd64 -I$(SRC_PATH)
-	LDFLAGS=-shared
-endif
-
-ifeq ($(PLATFORM),aix_ppc-32)
+ifeq ($(OS),aix)
 	CC=xlc
-	CFLAGS=-qstaticinline  -I$(SOLARIS_PATH) -I$(LINUX_PATH) -I$(SRC_PATH)
-	LDFLAGS=-G
+	CFLAGS=-qstaticinline -q$(BitMode) -I$(LINUX_PATH) -I$(SRC_PATH)
+	LDFLAGS=-G -q$(BitMode)
 endif
 
-ifeq ($(PLATFORM),aix_ppc-64)
-	CC=xlc
-	CFLAGS=-q64 -qstaticinline -D_LP64 -I$(SOLARIS_PATH) -I$(LINUX_PATH) -I$(SRC_PATH)
-	LDFLAGS=-G 
-endif
-
-ifeq ($(PLATFORM),linux_390-32)
-	CC=gcc
-	CFLAGS=-m31 -fPIC -I$(SOLARIS_PATH) -I$(LINUX_PATH) -I$(SRC_PATH)
-	LDFLAGS=-shared
-endif
-
-ifeq ($(PLATFORM),linux_390-64)
-	CC=gcc
-	CFLAGS=-fPIC -D_LP64 -m64 -I$(SOLARIS_PATH) -I$(LINUX_PATH) -I$(SRC_PATH)
-	LDFLAGS=-shared
-endif
-
-ifeq ($(PLATFORM),linux_arm-32)
-	CC=gcc
-	CFLAGS=-fPIC -m32 -I$(SOLARIS_PATH) -I$(LINUX_PATH) -I$(SRC_PATH)
-	LDFLAGS=-shared
-endif
-
-ifeq ($(PLATFORM),linux_arm-64)
-	CC=gcc
-	CFLAGS=-fPIC -D_LP64 -I$(SOLARIS_PATH) -I$(LINUX_PATH) -I$(SRC_PATH)
-	LDFLAGS=-shared
-endif
-
-ifeq ($(PLATFORM),linux_riscv-64)
-	CC=gcc
-	CFLAGS=-fPIC -D_LP64 -I$(SOLARIS_PATH) -I$(LINUX_PATH) -I$(SRC_PATH)
-	LDFLAGS=-shared
-endif
-
-ifeq ($(PLATFORM),zos_390-32)
+ifeq ($(OS),zos)
 	CC=c89
-	CFLAGS=-I$(SRCDIR)/src/share/lib/jni/include/unix -I$(SRCDIR)/src/share/lib/jni/include -I$(FULLOUTDIR)/include -I$(SRCDIR)/src -Wc,ASCII -W"c,xplink(backchain,oscall(downstack)),noansialias,float(ieee),langlvl(extended),ROCONST,ROSTRING,enum(4),noupconv,sscom" -W"c,target(zOSV2R2)" -W"c,inline(auto,noreport,1200,8000)" -W"a,goff,ESD" -W"c,dll,expo" -W"l,xplink,compat=min" -Wl,dll -Ds390 -DARCH='"s390"'
+	CFLAGS=-I$(UNIX_PATH) -I$(JNI_INCLUDE_PATH) -I$(FULLOUTDIR)/include -I$(SRCDIR)/src -Wc,ASCII -W"c,xplink(backchain,oscall(downstack)),noansialias,float(ieee),langlvl(extended),ROCONST,ROSTRING,enum(4),noupconv,sscom" -W"c,target(zOSV2R2)" -W"c,inline(auto,noreport,1200,8000)" -W"a,goff,ESD" -W"c,dll,expo" -W"l,xplink,compat=min" -Wl,dll -Ds390 -DARCH='"s390"'
 	LDFLAGS=-D_ALL_SOURCE -DUSE_MALLOC -DIBM_STACK_GROWS_UP -D_XOPEN_SOURCE_EXTENDED=1 -DIBM_ATOE -DOS390CTRACE -DIBM_WRITE_BARRIER -DIBM_MVS -DASYNCH_FI -DRASTRACE_TDF -DJNI_JCL_H -DIBM_ALL -DIBM_UNIX -D_POSIX_SOURCE -DSOLARIS2 -DIBM_OE_XWINDOWS -DIBM_NOAUDIO -DIBM_OE -DIBM_BUILD_TYPE_int -DJ9J2SE -D_BIG_ENDIAN -D_UNIX03_SOURCE -DSTDC -D_LARGE_FILES 
 endif
 
-#Warnings displayed can be ignored
-ifeq ($(PLATFORM),zos_390-64)
-	CC=c89
-	CFLAGS=-I$(SRCDIR)/src/share/lib/jni/include/unix -I$(SRCDIR)/src/share/lib/jni/include -I$(FULLOUTDIR)/include -I$(SRCDIR)/src -Wc,ASCII -W"c,lp64,warn64" -W"l,lp64" -W"c,check(port)" -W"c,xplink(backchain,oscall(downstack)),noansialias,float(ieee),langlvl(extended),ROCONST,ROSTRING,enum(4),noupconv,sscom" -W"c,target(zOSV2R2)" -W"c,inline(auto,noreport,1200,8000)" -W"a,goff,ESD" -W"c,dll,expo" -W"l,xplink,compat=min" -Wl,dll -Ds390 -DARCH='"s390"'
-	LDFLAGS=-D_ALL_SOURCE -DUSE_MALLOC -DIBM_STACK_GROWS_UP -D_XOPEN_SOURCE_EXTENDED=1 -DIBM_ATOE -DOS390CTRACE -DIBM_WRITE_BARRIER -DIBM_MVS -DASYNCH_FI -DRASTRACE_TDF -DJNI_JCL_H -DIBM_ALL -DIBM_UNIX -D_POSIX_SOURCE -DSOLARIS2 -DIBM_OE_XWINDOWS -DIBM_NOAUDIO -DIBM_OE -DIBM_BUILD_TYPE_int -DJ9J2SE -D_BIG_ENDIAN -D_UNIX03_SOURCE -DSTDC -D_LARGE_FILES 
-
-endif
-
-
-ifeq ($(WIN),1)
+ifeq ($(OS),win)
     ifeq (0,$(CYGWIN))
        SRCDIR := $(subst /,\,$(SRCDIR))
        OUTDIR := $(subst /,\,$(OUTDIR))
@@ -256,57 +208,13 @@ ifeq ($(WIN),1)
 	RANDOMGEN=cd $(FULLOUTDIR) && $(LINK_CMD) $(LFLAGS)"$(FULLOUTDIR)$(D)$@" $(FULLOUTDIR)$(D)com_sun_management_mbeans_loading_RandomGen.obj
 endif
 
-ifeq ($(PLATFORM),hp_ux-32)
-        CC=cc
-        CFLAGS=+DD32 +z -c -I$(SOLARIS_PATH) -I$(LINUX_PATH) -I$(SRC_PATH)
-        LDFLAGS=
-endif
-ifeq ($(PLATFORM),hp_ux-64)
-        CC=cc
-        CFLAGS=+DD64 +z -c -I$(SOLARIS_PATH) -I$(LINUX_PATH) -I$(SRC_PATH)
-        LDFLAGS=
-endif
-ifeq ($(PLATFORM),hp_ia-32)
-        CC=cc
-        CFLAGS=+DD32 +z -c -I$(SOLARIS_PATH) -I$(LINUX_PATH) -I$(SRC_PATH)
-        LDFLAGS=
-endif
-ifeq ($(PLATFORM),hp_ia-64)
-        CC=cc
-        CFLAGS=+DD64 +z -c -I$(SOLARIS_PATH) -I$(LINUX_PATH) -I$(SRC_PATH)
-        LDFLAGS=
-endif
-ifeq ($(PLATFORM),sol_sparc-32)
-        CC=gcc
-        CFLAGS=-nodefaultlibs -fPIC -I$(SOLARIS_PATH) -I$(LINUX_PATH) -I$(SRC_PATH)
-        LDFLAGS=-shared
-endif
-ifeq ($(PLATFORM),sol_sparc-64)
-        CC=gcc
-        CFLAGS= -m64 -nodefaultlibs -fPIC -R/usr/sfw/lib/64 -I$(SOLARIS_PATH) -I$(LINUX_PATH) -I$(SRC_PATH)
-        LDFLAGS=-shared
-endif
-ifeq ($(PLATFORM),sol_x86-32)
-        #CC=cc
-        #CFLAGS=-G -KPIC -I$(SOLARIS_PATH)
-	CC=gcc
-	CFLAGS=-G -fPIC -I$(SOLARIS_PATH) -I$(LINUX_PATH) -I$(SRC_PATH)
-        LDFLAGS=
-endif
-ifeq ($(PLATFORM),sol_x86-64)
-        #CC=gcc
-	CC=cc
-        CFLAGS=-m64 -fPIC -R/usr/sfw/lib/64 -I$(SOLARIS_PATH) -I$(LINUX_PATH) -I$(SRC_PATH)
-        LDFLAGS=-shared
-endif
-
 OBJS=$(LIBPREF)jckjni.$(LIBEXT)  $(LIBPREF)jckjvmti.$(LIBEXT) $(LIBPREF)systemInfo.$(LIBEXT) $(LIBPREF)jmxlibid.$(LIBEXT) $(LIBPREF)genrandom.$(LIBEXT)
 
 CFLAGS := $(CFLAGS) -I"$(SRCDIR)" -I"$(JNI_INCLUDE_PATH)" -I"$(JVMTI_INCLUDE_PATH)"
 .SUFFIXES:.c
 	
 help:
-	@echo "Usage: gmake build PLATFORM=<platform> SRCDIR=<JCK directory> OUTDIR=<target binaries directory>"
+	@echo "Usage: gmake build SRCDIR=<JCK directory> OUTDIR=<target binaries directory>"
 	@echo "Requirement : Default compiler and jar tool should be in path"
 	@echo platform:	aix_ppc-32
 	@echo   aix_ppc-64
@@ -329,10 +237,10 @@ help:
 	@echo   sol_sparc-64
 	@echo   sol_x86-32
 	@echo   sol_x86-64
-	@echo Binaries are placed in the directory OUTDIR/PLATFORM. 
+	@echo Binaries are placed in the directory OUTDIR/OS. 
 	@echo Examples:
-	@echo "gmake build PLATFORM=win_x86-32 SRCDIR=C:\jck\java8b\JCK-runtime-8b OUTDIR=C:\jck\java8b\natives" 
-	@echo "gmake build PLATFORM=linux_x86-32 SRCDIR=/jck/java8b/JCK-runtime-8b OUTDIR=/jck/java8b/natives" 
+	@echo "gmake build SRCDIR=C:\jck\java8b\JCK-runtime-8b OUTDIR=C:\jck\java8b\natives" 
+	@echo "gmake build SRCDIR=/jck/java8b/JCK-runtime-8b OUTDIR=/jck/java8b/natives" 
 
 build:createdir $(OBJS) installjmx
 
@@ -365,7 +273,7 @@ createdir:
 	$(MKDIR) $(FULLOUTDIR)
 	
 installjmx:
-ifeq ($(WIN),0)
+ifneq ($(OS),win)
 	$(COPYDIR) $(SRCDIR)$(D)tests$(D)api$(D)javax_management$(D)loading$(D)data$(D)* $(FULLOUTDIR)$(D).
 	cd $(FULLOUTDIR) && $(JAR) uf $(FULLOUTDIR)/archives/MBeanUseNativeLib.jar $(LIBPREF)systemInfo.$(LIBEXT)
 	cd $(FULLOUTDIR) && $(JAR) cf $(FULLOUTDIR)/archives/OnlyLibs.jar $(LIBPREF)jmxlibid.$(LIBEXT)
@@ -380,7 +288,7 @@ else
 endif
 
 .PHONY clean:
-ifeq ($(WIN),0)
+ifneq ($(OS),win)
 	$(CLEANFILE) *.x *.o *.obj 
 	$(CLEANFILE) $(FULLOUTDIR)/*.html
 	$(CLEANFILE)  $(FULLOUTDIR)/*.x

--- a/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
+++ b/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
@@ -207,7 +207,7 @@ public class Jck implements StfPluginInterface {
 		testSuiteFolder = "JCK-" + testSuite.toString().toLowerCase() + "-" + jckVersionNo;
 		platform = test.env().getOsgiOperatingSystemName();	
 		jckBase = test.env().findPrereqDirectory(testSuiteFolder);
-		nativesLoc = test.env().findPrereqDirectory("natives/" + test.env().getPlatform());
+		nativesLoc = test.env().findPrereqDirectory("natives/" + test.env().getPlatformSimple());
 
 		DirectoryRef repositoryConfigLoc = test.env().findTestDirectory("openjdk.test.jck/config");
 		jtiFile = repositoryConfigLoc.childFile("/" + jckVersion + "/" + testSuite.toString().toLowerCase() + ".jti");

--- a/openjdk.test.modularity/build.xml
+++ b/openjdk.test.modularity/build.xml
@@ -297,7 +297,7 @@ limitations under the License.
 	
 	<target name="setup-native-build-command" if="${can_build_modularity}">
 		<echo message="building natives for java_platform ${java_platform}"/>
-		<property name="openjdk_test_modularity_native_build_command" value='${setup_windows_build_env}${MAKE} -C ${openjdk_test_modularity_jlink_testcase_src}/native SRC=${openjdk_test_modularity_native_src} PLATFORM=${java_platform} JAVA_HOME=${java_home} OUTDIR=${openjdk_test_modularity_jlink_outdir} HEADERDIR=${openjdk_test_modularity_jlink_headerdir} OSNAME=${java_osname}'/>
+		<property name="openjdk_test_modularity_native_build_command" value='${setup_windows_build_env}${MAKE} -C ${openjdk_test_modularity_jlink_testcase_src}/native SRC=${openjdk_test_modularity_native_src} JAVA_HOME=${java_home} OUTDIR=${openjdk_test_modularity_jlink_outdir} HEADERDIR=${openjdk_test_modularity_jlink_headerdir} OSNAME=${java_osname}'/>
 		<tempfile property="openjdk_test_modularity_native_build_command_file" destDir="${java.io.tmpdir}" prefix="openjdk.build.command."/>
 	</target>
 

--- a/openjdk.test.modularity/src/com.stf/net/adoptopenjdk/test/modularity/JlinkPluginTest.java
+++ b/openjdk.test.modularity/src/com.stf/net/adoptopenjdk/test/modularity/JlinkPluginTest.java
@@ -102,7 +102,7 @@ public class JlinkPluginTest implements StfPluginInterface {
       helloDir = test.env().findTestDirectory("openjdk.test.modularity/bin/common-mods/com.hello");
       jLinkDir = test.env().findTestDirectory("openjdk.test.modularity/bin/tests/com.test.jlink");
 	  DirectoryRef confDir = test.env().findTestDirectory("openjdk.test.modularity/bin/tests/com.test.jlink/conf");
-	  DirectoryRef nativeDir = test.env().findTestDirectory("openjdk.test.modularity/bin/tests/com.test.jlink/native/bin/" + test.env().getPlatform());
+	  DirectoryRef nativeDir = test.env().findTestDirectory("openjdk.test.modularity/bin/tests/com.test.jlink/native/bin/" + test.env().getPlatformSimple());
 	  
 	  /*Creating a modularized jar / jmod out of com.test.jlink.*/ 
 		 

--- a/openjdk.test.modularity/src/com.stf/net/adoptopenjdk/test/modularity/JlinkTest.java
+++ b/openjdk.test.modularity/src/com.stf/net/adoptopenjdk/test/modularity/JlinkTest.java
@@ -95,7 +95,7 @@ public class JlinkTest implements StfPluginInterface {
 		
 		DirectoryRef jLinkDir = test.env().findTestDirectory("openjdk.test.modularity/bin/tests/com.test.jlink");
 		DirectoryRef confDir = test.env().findTestDirectory("openjdk.test.modularity/bin/tests/com.test.jlink/conf");
-		nativeDir = test.env().findTestDirectory("openjdk.test.modularity/bin/tests/com.test.jlink/native/bin/" + test.env().getPlatform());
+		nativeDir = test.env().findTestDirectory("openjdk.test.modularity/bin/tests/com.test.jlink/native/bin/" + test.env().getPlatformSimple());
 		DirectoryRef helloDir = test.env().findTestDirectory("openjdk.test.modularity/bin/common-mods/com.hello");
 		
 		/*Creating a modularized jar / jmod out of com.test.jlink.*/ 

--- a/openjdk.test.modularity/src/tests/com.test.jlink/native/makefile
+++ b/openjdk.test.modularity/src/tests/com.test.jlink/native/makefile
@@ -10,22 +10,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # 
-# Usage: gmake [target] [SRC=basename] [PLATFORM=platform] [OUTDIR=destdir] [JAVA_HOME=javadir] [HEADERDIR=headerdir]
+# Usage: gmake [target] [SRC=basename] [OUTDIR=destdir] [JAVA_HOME=javadir] [HEADERDIR=headerdir]
 #		 basename - The name of the C file to compile without the .c extension
 #        target -   The make target valid values for this makefile are build and clean
 #                   If no target is supplied the build target is used.
 #        platform - The platform to build for.  The valid values for this argument are
-#                   aix_ppc-32, aix_ppc-64, linux_390-31, linux_390-64, linux_ppc-32
-#                   linux_ppc-64, linux_x86-32, linux_x86-64, win_x86-32, win_x86-64
+#                   AIX_32, AIX_64, linux_390-31, linux_390-64, linux_ppc-32
+#                   linux_ppc-64, linux_x86-32, linux_x86-64, win_x86-32, Win_x86-32
 #                   zos_390-32, zos_390-64
 #        destdir  - The directory where a platform directory will be created and the shared library will be placed 
 #        javadir  - The java.home property directory (ie c:\sdk\jre)
 #        headerdir -The directory containing the header files.
 
-
+###
+# Figure out current platform
+###
+OS:=$(shell uname -s | tr "[:upper:]" "[:lower:]")
 
 .SUFFIXES: .c
-WIN=0
 
 CC=gcc
 LD=gcc
@@ -42,109 +44,56 @@ RM=rm -rf
 # chmod might return non zero if there is a file or directory the current user doesn't own,
 # so tell make to ignore failures
 CHMOD=- chmod
-
-DESTDIR=$(OUTDIR)/$(PLATFORM)
-OBJDIR=$(HEADERDIR)/$(PLATFORM)
-
 D=/
 P=:
 
-###
-# Check platform is set to a single valid value
-###
-VALID_PLATFORMS?=osx_x86-64,aix_ppc-32,aix_ppc-64,linux_390-32,linux_390-64,linux_ppc-32,linux_ppc-64,linux_x86-32,linux_x86-64,win_x86-32,win_x86-64,zos_390-32,zos_390-64,linux_ppcle-64,linux_arm-32,linux_arm-64,bsd_x86-64,linux_riscv-64
-ifndef PLATFORM
-  $(error "The variable PLATFORM needs to be defined")
-endif
-ifndef OSNAME
-  $(error "The variable OSNAME needs to be defined")
-endif
-space:=$(space) $(space)
-comma:=,
-ifneq "1" "$(words $(subst $(comma), ,$(PLATFORM)))"
-  $(error "The variable PLATFORM should only contain one of $(VALID_PLATFORMS)")
-endif
-ifneq "" "$(filter-out $(subst $(comma), ,$(VALID_PLATFORMS)),$(PLATFORM))"
-  $(error "The variable PLATFORM=$(PLATFORM) is not one of $(VALID_PLATFORMS)")
+ifneq (,$(findstring cygwin,$(OS)))
+	OS:=win
 endif
 
+ifeq ($(OS),darwin)
+	OS:=osx
+endif
+
+ifneq (,$(findstring win,$(OS)))
+	OS:=win
+endif
+
+ifeq ($(OS),os/390)
+	OS:=zos
+endif 
+
+$(info OS = $(OS))
+
+DESTDIR=$(OUTDIR)/$(OS)
+OBJDIR=$(HEADERDIR)/$(OS)
+
+space:=$(space) $(space)
+comma:=,
+
+# AIX requires bitmode value to be passed into compilar flags
+ifeq ($(OS),aix)
+	BitMode:=$(shell getconf KERNEL_BITMODE)
+endif 
+
 CFLAGS=-D_JNI_IMPLEMENTATION_ -D_TRIVIAL_AGENT -O0 -g3 -pedantic -c -Wall -std=c99 -fPIC -fno-omit-frame-pointer -static-libgcc -o $(OBJDIR)/$(SRC)$(OSUFFIX)
-LFLAGS=-shared -o 
+LFLAGS=-L. -L../bin/* -shared -o
 # Cater for JAVA_HOME being set either to the jre dir or the parent directory
 IFLAGS=-I. -I$(HEADERDIR) -I$(JAVA_HOME)/include/${OSNAME} -I$(JAVA_HOME)/include -I/usr/include
 
 RMLIST=*.o
 
-ifeq ($(PLATFORM),linux_x86-32)
-	CFLAGS=-D_JNI_IMPLEMENTATION_ -D_TRIVIAL_AGENT -O0 -g3 -pedantic -c -Wall -std=c99 -fPIC -fno-omit-frame-pointer -static-libgcc -m32 -o $(OBJDIR)/$(SRC)$(OSUFFIX)
-	LFLAGS=-shared -m32 -o 
-endif
-
-ifeq ($(PLATFORM),linux_x86-64)
-	CFLAGS=-D_JNI_IMPLEMENTATION_ -D_TRIVIAL_AGENT -O0 -g3 -pedantic -c -Wall -std=c99 -fPIC -fno-omit-frame-pointer -static-libgcc -m64 -o $(OBJDIR)/$(SRC)$(OSUFFIX)
-	LFLAGS=-shared -m64 -o 
-endif
-
-ifeq ($(PLATFORM),linux_ppc-32)
-    CFLAGS=-D_JNI_IMPLEMENTATION_ -D_TRIVIAL_AGENT -O0 -g3 -pedantic -c -Wall -std=c99 -fPIC -fno-omit-frame-pointer -static-libgcc -m32 -o $(OBJDIR)/$(SRC)$(OSUFFIX)
-    LFLAGS=-L. -L../bin/$(PLATFORM) -m32 -shared -o 
-endif
-
-ifeq ($(PLATFORM),linux_ppc-64)
-    CFLAGS=-D_JNI_IMPLEMENTATION_ -D_TRIVIAL_AGENT -O0 -g3 -pedantic -c -Wall -std=c99 -fPIC -fno-omit-frame-pointer -static-libgcc -m64 -mcpu=powerpc64 -o $(OBJDIR)/$(SRC)$(OSUFFIX)
-    LFLAGS=-L. -L../bin/$(PLATFORM) -m64 -shared -o 
-endif
-
-ifeq ($(PLATFORM),linux_ppcle-64)
-    CFLAGS=-D_JNI_IMPLEMENTATION_ -D_TRIVIAL_AGENT -O0 -g3 -pedantic -c -Wall -std=c99 -fPIC -fno-omit-frame-pointer -static-libgcc -m64 -mcpu=powerpc64 -o $(OBJDIR)/$(SRC)$(OSUFFIX)
-    LFLAGS=-L. -L../bin/$(PLATFORM) -m64 -shared -o 
-endif
-
-ifeq ($(PLATFORM),linux_390-32)
-    CFLAGS=-D_JNI_IMPLEMENTATION_ -D_TRIVIAL_AGENT -O0 -g3 -pedantic -c -Wall -std=c99 -fPIC -fno-omit-frame-pointer -static-libgcc -m31 -o $(OBJDIR)/$(SRC)$(OSUFFIX)
-    LFLAGS=-m31 -shared -o
-endif
-
-ifeq ($(PLATFORM),linux_arm-32)
-	CFLAGS=-D_JNI_IMPLEMENTATION_ -D_TRIVIAL_AGENT -O0 -g3 -pedantic -c -Wall -std=c99 -fPIC -fno-omit-frame-pointer -static-libgcc -o $(OBJDIR)/$(SRC)$(OSUFFIX)
-	LFLAGS=-shared -o 
-endif
-
-ifeq ($(PLATFORM),linux_arm-64)
-	CFLAGS=-D_JNI_IMPLEMENTATION_ -D_TRIVIAL_AGENT -O0 -g3 -pedantic -c -Wall -std=c99 -fPIC -fno-omit-frame-pointer -static-libgcc -o $(OBJDIR)/$(SRC)$(OSUFFIX)
-	LFLAGS=-shared -o 
-endif
-
-ifeq ($(PLATFORM),osx_x86-64)
+ifeq ($(OS),osx)
     SUFFIX=.dylib
-    CFLAGS=-D_JNI_IMPLEMENTATION_ -D_TRIVIAL_AGENT -O0 -g3 -pedantic -c -Wall -std=c99 -fPIC -fno-omit-frame-pointer -m64 -o $(OBJDIR)/$(SRC)$(OSUFFIX)
-    LFLAGS=-m64 -dynamiclib -o
+    LFLAGS=-dynamiclib -o
     IFLAGS=-I. -I$(HEADERDIR) -I$(JAVA_HOME)/include/darwin -I$(JAVA_HOME)/include -I/usr/include
 endif
-ifeq ($(PLATFORM),win_x86-32)
-    DESTDIR=$(OUTDIR)\$(PLATFORM)
-    WIN=1
+
+ifeq ($(OS),Win)
+    DESTDIR=$(OUTDIR)\$(OS)
 endif
 
-ifeq ($(PLATFORM),win_x86-64)
-    DESTDIR=$(OUTDIR)\$(PLATFORM)
-    WIN=1
-endif
- 
-ifeq ($(PLATFORM),bsd_x86-64)
-    CC=cc
-    LD=cc
-    IFLAGS=-I. -I$(HEADERDIR) -I$(JAVA_HOME)/include/$(shell uname | tr "[:upper:]" "[:lower:]") -I$(JAVA_HOME)/include -I/usr/include
-    CFLAGS=-D_JNI_IMPLEMENTATION_ -D_TRIVIAL_AGENT -O0 -g3 -pedantic -c -Wall -std=c99 -fPIC -fno-omit-frame-pointer -m64 -o $(OBJDIR)/$(SRC)$(OSUFFIX)
-    LFLAGS=-shared -m64 -o
-endif
-
-ifeq ($(PLATFORM),linux_riscv-64)
-	CFLAGS=-D_JNI_IMPLEMENTATION_ -D_TRIVIAL_AGENT -O0 -g3 -pedantic -c -Wall -std=c99 -fPIC -fno-omit-frame-pointer -static-libgcc -o $(OBJDIR)/$(SRC)$(OSUFFIX)
-	LFLAGS=-shared -o 
-endif
-
-ifeq ($(WIN),1)
+ifeq ($(OS),win)
 
     # Environment variable OSTYPE is set to cygwin if running under cygwin.
     # Set our own macro to indicate we're running under cygwin.
@@ -187,7 +136,7 @@ ifeq ($(WIN),1)
     OSUFFIX=.obj
     ESUFFIX=.exe
 
-    CFLAGS=/DWIN32 /D_WINDOWS -Gy /LD /Zi /Odi /c /RTC1 /Fo"$(OBJDIR)/$(SRC)$(OSUFFIX)" /Fd"$(OBJDIR)/$(PLATFORM)"
+    CFLAGS=/DWIN32 /D_WINDOWS -Gy /LD /Zi /Odi /c /RTC1 /Fo"$(OBJDIR)/$(SRC)$(OSUFFIX)" /Fd"$(OBJDIR)/$(OS)"
     LFLAGS=/NOLOGO /DLL /INCREMENTAL:NO /NODEFAULTLIB:LIBCMTD /OUT:
 	# Cater for JAVA_HOME being set either to the jre dir or the parent directory
     IFLAGS=/I. /I"$(HEADERDIR)" /I"$(JAVA_HOME)/../include" /I"$(JAVA_HOME)/../include/win32" /I"$(JAVA_HOME)/include" /I"$(JAVA_HOME)/include/win32"
@@ -195,47 +144,27 @@ ifeq ($(WIN),1)
     RMLIST=*.exp *.lib *.obj
 endif
 
-ifeq ($(PLATFORM),zos_390-64)
+ifeq ($(OS),zos)
     CC=c89
     LD=c89
-
-    CFLAGS=-Wc,lp64,warn64 -W c,exportall -W c,exportall -D_JNI_IMPLEMENTATION -D_TRIVIAL_AGENT -W "c,langlvl(extended)" -W "c,float(ieee)" -W "c,c,convlit(ISO8859-1)" -DZOS -c -o $(OBJDIR)/$(SRC)$(OSUFFIX)
-    LFLAGS=-Wl,lp64,amode=64 -W l,XPLINK,dll -o 
-    #IFLAGS=-I. -I$(HEADERDIR) -I$(JAVA_HOME)/include -I/usr/include
-    RMLIST=*.o *.x
-endif
-
-ifeq ($(PLATFORM),zos_390-32)
-    CC=c89
-    LD=c89
-
     CFLAGS=-W c,exportall -D_JNI_IMPLEMENTATION -D_TRIVIAL_AGENT -W "c,langlvl(extended)" -W "c,float(ieee)" -W "c,convlit(ISO8859-1)" -W "c,xplink,dll" -W "l,xplink,dll" -DZOS -c -o $(OBJDIR)/$(SRC)$(OSUFFIX)
     LFLAGS=-W l,XPLINK,dll -o 
-    #IFLAGS=-I. -I$(HEADERDIR) -I$(JAVA_HOME)/include -I/usr/include
     RMLIST=*.o *.x
 endif
 
-ifeq ($(PLATFORM),aix_ppc-64)
+ifeq ($(OS),aix)
     CC=xlC
     LD=xlC
-
-    CFLAGS=-D_JNI_IMPLEMENTATION -D_TRIVIAL_AGENT -qnooptimize -g -qlanglvl=stdc99 -q64 -c -o $(OBJDIR)/$(SRC)$(OSUFFIX)
-    LFLAGS=-G -q64 -o 
+    CFLAGS=-D_JNI_IMPLEMENTATION -D_TRIVIAL_AGENT -qnooptimize -g -qlanglvl=stdc99 -q$(BitMode) -c -o $(OBJDIR)/$(SRC)$(OSUFFIX)
+    LFLAGS=-G -q$(BitMode) -o 
 endif
 
-ifeq ($(PLATFORM),aix_ppc-32)
-    CC=xlC
-    LD=xlC
-
-    CFLAGS=-D_JNI_IMPLEMENTATION -D_TRIVIAL_AGENT -qnooptimize -g -qlanglvl=stdc99 -q32 -c -o $(OBJDIR)/$(SRC)$(OSUFFIX)
-    LFLAGS=-G -q32 -o 
-endif
 
 ##########################################
 # Find the java executable under JAVA_HOME
 ##########################################
 
-ifeq ($(WIN),1)
+ifeq ($(OS),win)
   file_exists = $(shell $(CMD_PREFIX) if exist $(1) echo file exists)
 else
   file_exists = $(shell if [ -f  $(1) ] ; then echo file exists; fi;)
@@ -264,14 +193,14 @@ jni: $(DESTDIR) $(OBJDIR) $(DESTDIR)/$(PREFIX)$(SRC)$(SUFFIX)
 
 $(DESTDIR)/$(PREFIX)$(SRC)$(SUFFIX): $(OBJDIR)/$(SRC)$(OSUFFIX)
 # Build the shared library
-ifeq ($(PLATFORM),osx_x86-64)
+ifeq ($(OS),osx)
 	$(CMD_PREFIX) $(LD) $(LFLAGS) $(DESTDIR)/$(PREFIX)$(SRC)$(SUFFIX) $(OBJDIR)/$(SRC)$(OSUFFIX)
 else
 	$(CMD_PREFIX) $(LD) $(LFLAGS)$(DESTDIR)/$(PREFIX)$(SRC)$(SUFFIX) $(OBJDIR)/$(SRC)$(OSUFFIX)
 endif
 # chmod might return non zero if there is a file or directory the current user doesn't own,
 # so tell make to ignore failures
-ifneq ($(WIN),1)
+ifneq ($(OS),win)
 	$(CHMOD) 755 $@
 endif
 
@@ -281,19 +210,19 @@ endif
 
 $(OBJDIR)/$(SRC)$(OSUFFIX): $(SRC).c $(HEADERDIR)/adoptopenjdk_test_modularity_jlink_$(SRC).h
 	$(CMD_PREFIX) $(CC) $(CFLAGS) $(IFLAGS) $(SRC).c
-ifneq ($(WIN),1)
+ifneq ($(OS),win)
 	$(CHMOD) 755 $@
 endif
 
 $(DESTDIR):
 	$(MKDIR) $(DESTDIR)
-ifneq ($(WIN),1)
+ifneq ($(OS),win)
 	$(CHMOD) 755 $(DESTDIR)
 endif
 
 $(OBJDIR):
 	$(MKDIR) $(OBJDIR)
-ifneq ($(WIN),1)
+ifneq ($(OS),win)
 	$(CHMOD) 755 $(OBJDIR)
 endif
 
@@ -305,5 +234,5 @@ $(HEADERDIR)/adoptopenjdk_test_modularity_jlink_$(SRC).h:
 	echo $(HEADERDIR)/adoptopenjdk_test_modularity_jlink_$(SRC).h is out of date or not present
 
 clean:
-	$(RMDIR) $(OUTDIR)/$(PLATFORM)
-	$(RMDIR) $(HEADERDIR)/$(PLATFORM)
+	$(RMDIR) $(OUTDIR)/$(OS)
+	$(RMDIR) $(HEADERDIR)/$(OS)


### PR DESCRIPTION
- Remove dependency of systemtest native makefiles on on PLATFORM variable 
- Use uname commands to figure out platforms and platforms specific compiler settings 
- Reduce unnecessary platform-specific compiler flags

Related to  : https://github.com/AdoptOpenJDK/openjdk-systemtest/issues/413
Related PR : https://github.com/eclipse/openj9-systemtest/pull/128

Signed-off-by: Mesbah_Alam@ca.ibm.com <Mesbah_Alam@ca.ibm.com>