### PR TITLE
Re-enable exp() tests on x86

### DIFF
--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/math/MathAPITest.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/math/MathAPITest.java
@@ -1268,19 +1268,19 @@ assertTrue("exp(double)[17] ::", 0.9999999999999998 <= Math.exp(0D) && 1.0000000
 assertEquals("exp(double)[18] ::", 11.3842406513381, StrictMath.exp(2.43223D));
 assertTrue("exp(double)[19] ::", 11.384240651338098 <= Math.exp(2.43223D) && 11.384240651338102 >= Math.exp(2.43223D));
 assertEquals("exp(double)[20] ::", Infinity, StrictMath.exp(18232155.3323566D));
-if ( ! ( System.getProperty("sun.arch.data.model").equals("32") && System.getProperty("os.name").toLowerCase().contains("win") && runtimeJdkRange.equals("notPreJdk9") ) ) {assertEquals("exp(double)[21] ::", Infinity, Math.exp(18232155.3323566D));}
+assertEquals("exp(double)[21] ::", Infinity, Math.exp(18232155.3323566D));
 assertEquals("exp(double)[22] ::", 1.0, StrictMath.exp(Double.MIN_VALUE));
 assertTrue("exp(double)[23] ::", 0.9999999999999998 <= Math.exp(Double.MIN_VALUE) && 1.0000000000000002 >= Math.exp(Double.MIN_VALUE));
 assertEquals("exp(double)[24] ::", 1.0, StrictMath.exp((Double.MIN_VALUE * 200)));
 assertTrue("exp(double)[25] ::", 0.9999999999999998 <= Math.exp((Double.MIN_VALUE * 200)) && 1.0000000000000002 >= Math.exp((Double.MIN_VALUE * 200)));
 assertEquals("exp(double)[26] ::", Infinity, StrictMath.exp((Double.MAX_VALUE / 500)));
-if ( ! ( System.getProperty("sun.arch.data.model").equals("32") && System.getProperty("os.name").toLowerCase().contains("win") && runtimeJdkRange.equals("notPreJdk9") ) ) {assertEquals("exp(double)[27] ::", Infinity, Math.exp((Double.MAX_VALUE / 500)));}
+assertEquals("exp(double)[27] ::", Infinity, Math.exp((Double.MAX_VALUE / 500)));
 assertEquals("exp(double)[28] ::", Infinity, StrictMath.exp((Double.MAX_VALUE / 200)));
-if ( ! ( System.getProperty("sun.arch.data.model").equals("32") && System.getProperty("os.name").toLowerCase().contains("win") && runtimeJdkRange.equals("notPreJdk9") ) ) {assertEquals("exp(double)[29] ::", Infinity, Math.exp((Double.MAX_VALUE / 200)));}
+assertEquals("exp(double)[29] ::", Infinity, Math.exp((Double.MAX_VALUE / 200)));
 assertEquals("exp(double)[30] ::", Infinity, StrictMath.exp(Double.MAX_VALUE));
-if ( ! ( System.getProperty("sun.arch.data.model").equals("32") && System.getProperty("os.name").toLowerCase().contains("win") && runtimeJdkRange.equals("notPreJdk9") ) ) {assertEquals("exp(double)[31] ::", Infinity, Math.exp(Double.MAX_VALUE));}
+assertEquals("exp(double)[31] ::", Infinity, Math.exp(Double.MAX_VALUE));
 assertEquals("exp(double)[32] ::", Infinity, StrictMath.exp(Double.MAX_VALUE + 1));
-if ( ! ( System.getProperty("sun.arch.data.model").equals("32") && System.getProperty("os.name").toLowerCase().contains("win") && runtimeJdkRange.equals("notPreJdk9") ) ) {assertEquals("exp(double)[33] ::", Infinity, Math.exp(Double.MAX_VALUE + 1));}
+assertEquals("exp(double)[33] ::", Infinity, Math.exp(Double.MAX_VALUE + 1));
 }
 
 public void testExpm1()

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/math/MathAPITestGenerator.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/math/MathAPITestGenerator.java
@@ -646,10 +646,6 @@ public class MathAPITestGenerator
 		// **************************************************************************************
 		
 		// exp - double
-		// Exclude Math.exp on win_x86-32 hotspot jdk11 or later when the expected result is
-		// Infinity pending resolution to issues:
-		// https://github.com/AdoptOpenJDK/openjdk-tests/issues/2062
-		// https://github.com/AdoptOpenJDK/openjdk-support/issues/182
 		// **************************************************************************************
 		testCount = 0;
 		System.out.println("public void testExp()");
@@ -658,8 +654,7 @@ public class MathAPITestGenerator
 		{
 			System.out.println("assertEquals(\"exp(double)["+testCount+++"] ::\", " + StrictMath.exp(doubleTestValues[i]) + ", StrictMath.exp("+doubleTestStrings[i]+"));");
 			if ( Double.isInfinite(StrictMath.exp(doubleTestValues[i])) ) {
-				System.out.println("if ( ! ( System.getProperty(\"sun.arch.data.model\").equals(\"32\") && System.getProperty(\"os.name\").toLowerCase().contains(\"win\") && runtimeJdkRange.equals(\"notPreJdk9\") ) ) {assertEquals(\"exp(double)["+testCount+++"] ::\", " + StrictMath.exp(doubleTestValues[i]) + ", Math.exp("+doubleTestStrings[i]+"));}");
-				//System.out.println("assertEquals(\"exp(double)["+testCount+++"] ::\", " + StrictMath.exp(doubleTestValues[i]) + ", Math.exp("+doubleTestStrings[i]+"));");
+				System.out.println("assertEquals(\"exp(double)["+testCount+++"] ::\", " + StrictMath.exp(doubleTestValues[i]) + ", Math.exp("+doubleTestStrings[i]+"));");
 			}
 			else {
 				dTolerance = StrictMath.ulp(StrictMath.exp(doubleTestValues[i]));


### PR DESCRIPTION
Problem has been fixed: https://bugs.openjdk.java.net/browse/JDK-8255368.

Resolves https://github.com/AdoptOpenJDK/openjdk-tests/issues/2062.