### PR TITLE
force natives to be compiled in 64bit on solaris

### DIFF
--- a/openjdk.test.jck/src/native/makefile
+++ b/openjdk.test.jck/src/native/makefile
@@ -150,8 +150,8 @@ ifeq ($(OS),osx)
 endif
 
 ifeq ($(OS),sunos)
-	CC=cc —m64
-	CFLAGS=-fPIC -I$(SOLARIS_PATH) -I$(SRC_PATH)
+	CC=cc
+	CFLAGS=-fPIC -m64 -I$(SOLARIS_PATH) -I$(SRC_PATH)
 	LDFLAGS=-shared
 endif
 

--- a/openjdk.test.jck/src/native/makefile
+++ b/openjdk.test.jck/src/native/makefile
@@ -150,8 +150,8 @@ ifeq ($(OS),osx)
 endif
 
 ifeq ($(OS),sunos)
-	CC=cc
-	CFLAGS=-fPIC —m64 -I$(SOLARIS_PATH) -I$(SRC_PATH)
+	CC=cc —m64
+	CFLAGS=-fPIC -I$(SOLARIS_PATH) -I$(SRC_PATH)
 	LDFLAGS=-shared
 endif
 

--- a/openjdk.test.jck/src/native/makefile
+++ b/openjdk.test.jck/src/native/makefile
@@ -151,7 +151,7 @@ endif
 
 ifeq ($(OS),sunos)
 	CC=cc
-	CFLAGS=-fPIC -I$(SOLARIS_PATH) -I$(SRC_PATH)
+	CFLAGS=-fPIC —m64 -I$(SOLARIS_PATH) -I$(SRC_PATH)
 	LDFLAGS=-shared
 endif
 


### PR DESCRIPTION
Currently, the native libs on Solaris are being compiled in 32bit rather than 64bit. This PR add's the `-m64` flag to force the compiler to use 64bit.

fixes:

```bash
wrong ELF class: ELFCLASS32 (Possible cause: architecture word width mismatch)
```