### PR TITLE
Add UNIX_PATH to default CFLAGS

### DIFF
--- a/openjdk.test.jck/src/native/makefile
+++ b/openjdk.test.jck/src/native/makefile
@@ -140,7 +140,7 @@ SRC_PATH=$(SRCDIR)/src
 # From jck10 the unix include files are in src/share/lib/jni/include/linux
 
 CC=gcc
-CFLAGS=-fPIC -I$(LINUX_PATH) -I$(SRC_PATH)
+CFLAGS=-fPIC -I$(UNIX_PATH) -I$(LINUX_PATH) -I$(SRC_PATH)
 LDFLAGS=-shared 
 
 ifeq ($(OS),osx)


### PR DESCRIPTION
For JCK8 to compile, we need to pass into the CFLAGS the path to the folder containing `jckjni_md.h`.  This was removed by https://github.com/adoptium/aqa-systemtest/pull/430/files#diff-ce706353a6b9b131babe2b82433446abac32dc9cfd44b16cabd4c5272d7724dbL143. 

In this PR, to remove confusion, we are using the `UNIX_PATH` variable in the default CFLAG values to supply the path to the headers - which solves the JCK8 compile issue. For later versions we do not see the issue as for those we have the "linux" folder which contains the headers. 

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>