### PR TITLE
Re-introduce SOLARIS_PATH for linux TCK compilation

### DIFF
--- a/openjdk.test.jck/src/native/makefile
+++ b/openjdk.test.jck/src/native/makefile
@@ -140,7 +140,7 @@ SRC_PATH=$(SRCDIR)/src
 # From jck10 the unix include files are in src/share/lib/jni/include/linux
 
 CC=gcc
-CFLAGS=-fPIC -I$(LINUX_PATH) -I$(SRC_PATH)
+CFLAGS=-fPIC -I$(SOLARIS_PATH) -I$(LINUX_PATH) -I$(SRC_PATH)
 LDFLAGS=-shared 
 
 ifeq ($(OS),osx)


### PR DESCRIPTION
`jckjni_md.h` is actually located in the Solaris directory but is needed on Linux as well

I removed this as part of https://github.com/adoptium/aqa-systemtest/pull/430