### PR TITLE
Excluding StringIndexOutOfBoundsException.constructor

### DIFF
--- a/openjdk.test.load/config/inventories/mauve/mauve_all_exclude.xml
+++ b/openjdk.test.load/config/inventories/mauve/mauve_all_exclude.xml
@@ -1,4 +1,11 @@
 <inventory>
+	<!-- Fails on JDK11 and up if run many times.
+		 Issue: https://github.com/adoptium/aqa-tests/issues/2293
+		 Note: The issue has been fixed upstream, and has been backported.
+		 We're waiting for the fix to move from JDKx-dev forks into JDKx.
+	-->
+	<mauve class="gnu.testlet.java.lang.StringIndexOutOfBoundsException.constructor"/>
+	
 	<!-- Excluded as invalid test. Ref: https://github.com/eclipse/openj9/issues/7020 -->
 	<mauve class="gnu.testlet.java.io.InputStreamReader.utf8"/>
 	<!-- Disabled as the following sub-tests are incompatible with jdk16 on HotSpot -->

--- a/openjdk.test.load/config/inventories/mauve/mauve_multiThread_exclude.xml
+++ b/openjdk.test.load/config/inventories/mauve/mauve_multiThread_exclude.xml
@@ -1,4 +1,11 @@
 <inventory>
+	<!-- Fails on JDK11 and up if run many times.
+		 Issue: https://github.com/adoptium/aqa-tests/issues/2293
+		 Note: The issue has been fixed upstream, and has been backported.
+		 We're waiting for the fix to move from JDKx-dev forks into JDKx.
+	-->
+	<mauve class="gnu.testlet.java.lang.StringIndexOutOfBoundsException.constructor"/>
+	
 	<!-- Disabled as the following sub-tests are incompatible with jdk16 on HotSpot -->
 	<!-- Details in issue: https://github.com/adoptium/aqa-tests/issues/2150 -->
 	<mauve class="gnu.testlet.java.util.HashMap.AcuniaHashMapTest"/>


### PR DESCRIPTION
Excluding a failing test until its fix propagates into the right
repositories upstream. Right now they're in JDKx-dev, and we need
them in JDKx. We expect this to happen over the next few weeks,
possibly after the quarterly updates.

Signed-off-by: Adam Farley <adfarley@redhat.com>