### PR TITLE
Enforce using bash for jck schema scripts on linux

### DIFF
--- a/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
+++ b/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
@@ -850,6 +850,12 @@ public class Jck implements StfPluginInterface {
 			} else {
 				throw new StfException("Unknown platform:: " + platform);
 			}
+
+                        if (platform.equals("linux")) {
+				// bash required to run schema scripts on linux (cannot be standard sh)
+				xjcCmd = "bash "+xjcCmd;
+				jxcCmd = "bash "+jxcCmd;
+                        }
 			
 			fileContent += "concurrency " + concurrencyString + ";\n";
 			fileContent += "timeoutfactor 1" + ";\n";							// All Devtools tests take less than 1h to finish.


### PR DESCRIPTION
The xjc.sh script is based on ksh minumum syntax and as such will not work with standard "sh".
This PR mandates the use of bash on linux platforms.
The javatest framework launches the scripts via a Java ProcessCommand and as such will not use a shell.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>