### PR TITLE
Update AIX parameters in TCK makefile to allow native builds

### DIFF
--- a/openjdk.test.jck/src/native/makefile
+++ b/openjdk.test.jck/src/native/makefile
@@ -156,8 +156,8 @@ ifeq ($(OS),sunos)
 endif
 
 ifeq ($(OS),aix)
-	CC=xlc
-	CFLAGS=-qstaticinline -q$(BitMode) -I$(UNIX_PATH) -I$(LINUX_PATH) -I$(SRC_PATH)
+	CC=/opt/IBM/xlC/13.1.3/bin/xlc
+	CFLAGS=-qstaticinline -q$(BitMode) -I$(UNIX_PATH) -I$(OSX_PATH) -I$(SRC_PATH)
 	LDFLAGS=-G -q$(BitMode)
 endif
 


### PR DESCRIPTION
I'd be ok if we decided to switch to using `xlc` from the PATH, but the natives are currently trying to reference a nonexistant `linux` directory. I believe `amd64` will be ok for this as a default directory to use, but we'll see how well the latest test run goes. It could probably use a bit of a subsequent variable name refactor since using `OSX_PATH` on AIX is rather odd ...

We may wish to check this with anyone else utilising this part of the `aqa-systemtest` repository.

Signed-off-by: Stewart X Addison <sxa@redhat.com>