### PR TITLE
skip setting localHostIPAddr on Solaris

### DIFF
--- a/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
+++ b/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
@@ -668,14 +668,14 @@ public class Jck implements StfPluginInterface {
 			}	
 			if ( tests.contains("api/java_net") || tests.contains("api/java_nio") || tests.equals("api") ) {
 				fileContent += "set jck.env.runtime.net.localHostName " + hostname + ";\n";
-				// The Solaris tests fail with this: specified tag "jck.env.runtime.net.localHostIPAddr" was not found on path. The path is:jck.intro
+				// The Solaris tests fail with this: specified tag "jck.env.runtime.net.*" was not found on path. The path is:jck.intro
 				if (!platform.equals("solaris")) {
 					fileContent += "set jck.env.runtime.net.localHostIPAddr " + ipAddress + ";\n";
+					fileContent += "set jck.env.runtime.net.testHost1Name " + testHost1Name + ";\n";
+					fileContent += "set jck.env.runtime.net.testHost1IPAddr " + testHost1Ip + ";\n";
+					fileContent += "set jck.env.runtime.net.testHost2Name " + testHost2Name + ";\n";
+					fileContent += "set jck.env.runtime.net.testHost2IPAddr " + testHost2Ip + ";\n";
 				}
-				fileContent += "set jck.env.runtime.net.testHost1Name " + testHost1Name + ";\n";
-				fileContent += "set jck.env.runtime.net.testHost1IPAddr " + testHost1Ip + ";\n";
-				fileContent += "set jck.env.runtime.net.testHost2Name " + testHost2Name + ";\n";
-				fileContent += "set jck.env.runtime.net.testHost2IPAddr " + testHost2Ip + ";\n";
 			}
 			if ( tests.contains("api/java_net") || tests.equals("api") ) {
 				fileContent += "set jck.env.runtime.url.httpURL " + httpUrl + ";\n";

--- a/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
+++ b/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
@@ -668,7 +668,10 @@ public class Jck implements StfPluginInterface {
 			}	
 			if ( tests.contains("api/java_net") || tests.contains("api/java_nio") || tests.equals("api") ) {
 				fileContent += "set jck.env.runtime.net.localHostName " + hostname + ";\n";
-				fileContent += "set jck.env.runtime.net.localHostIPAddr " + ipAddress + ";\n";
+				// The Solaris tests fail with this: specified tag "jck.env.runtime.net.localHostIPAddr" was not found on path. The path is:jck.intro
+				if (!platform.equals("solaris")) {
+					fileContent += "set jck.env.runtime.net.localHostIPAddr " + ipAddress + ";\n";
+				}
 				fileContent += "set jck.env.runtime.net.testHost1Name " + testHost1Name + ";\n";
 				fileContent += "set jck.env.runtime.net.testHost1IPAddr " + testHost1Ip + ";\n";
 				fileContent += "set jck.env.runtime.net.testHost2Name " + testHost2Name + ";\n";


### PR DESCRIPTION
fixes:

```output
JCK stderr + set jck.env.runtime.net.localHostIPAddr 147.75.85.211
JCK stderr Configuration file can not be imported due to question with specified tag "jck.env.runtime.net.localHostIPAddr" was not found on path. The path is:jck.intro
JCK stderr jck.env.simpleOrAdvanced (advanced)
```