### PR TITLE
Use .so instead of .a for AIX shlib extension in JCK natives

### DIFF
--- a/openjdk.test.jck/src/native/makefile
+++ b/openjdk.test.jck/src/native/makefile
@@ -93,7 +93,7 @@ endif
 # Following defaults set for Unix environment. For Windows platform following variables are overriden
 LIBPREF=lib
 ifneq (,$(findstring aix,$(OS)))
-	LIBEXT=a
+	LIBEXT=so
 else
 ifneq (,$(findstring osx,$(OS)))
 	LIBEXT=dylib


### PR DESCRIPTION
Bits of the TCK seem to be expecting this to be `.so` instead of `.a`

Signed-off-by: Stewart X Addison <sxa@redhat.com>