### PR TITLE
Change JCK8 AIX to use cmdAsString rather than cmdAsFile

### DIFF
--- a/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
+++ b/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
@@ -764,8 +764,8 @@ public class Jck implements StfPluginInterface {
 				// set the file and path separators (an error is thrown if they are set).
 				fileContent += "set jck.env.testPlatform.os \"Windows\";\n";
 				fileContent += "set jck.env.testPlatform.systemRoot " + System.getenv("WINDIR") + ";\n";
-			} else if (platform.equals("zos") || platform.equals("aix")) {
-				// On z/OS and AIX set the testplatform.os Current system
+			} else if (!jckVersion.contains("jck8") && (platform.equals("zos") || platform.equals("aix"))) {
+				// On jck11+ z/OS and AIX set the testplatform.os Current system
 				// due to JCK class OsHelper bug with getFileSep() in Compiler JCK Interviewer
 				fileContent += "set jck.env.testPlatform.os \"Current system\";\n";
 				cmdAsStringOrFile = "cmdAsFile";
@@ -800,8 +800,8 @@ public class Jck implements StfPluginInterface {
 			}
 			fileContent += "set jck.env.compiler.compRefExecute." + cmdAsStringOrFile + " \"" + pathToJava + "\"" + ";\n";
 
-			if (platform.equals("zos") || platform.equals("aix")) {
-                                // On z/OS and AIX set the compRefExecute file and path separators
+			if (!jckVersion.contains("jck8") && (platform.equals("zos") || platform.equals("aix"))) {
+                                // On jck11+ z/OS and AIX set the compRefExecute file and path separators
                                 // due to JCK class OsHelper bug with getFileSep() in Compiler JCK Interviewer
                                 fileContent += "set jck.env.compiler.compRefExecute.fileSep \"/\";\n";
                                 fileContent += "set jck.env.compiler.compRefExecute.pathSep \":\";\n";


### PR DESCRIPTION
This previous fix for JCK11 does not apply to JCK8 as OsHelper class is jck11+ only: https://github.com/adoptium/aqa-systemtest/commit/af676759f9365f29533837b466bb1a38a92be4db

Added condition to only use workaround for jck11+.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>