### PR TITLE
Run xjcCmd through ksh on Solaris

### DIFF
--- a/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
+++ b/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
@@ -854,10 +854,13 @@ public class Jck implements StfPluginInterface {
 				throw new StfException("Unknown platform:: " + platform);
 			}
 
+			// bash/ksh required to run schema scripts (cannot be standard sh)
                         if (platform.equals("linux")) {
-				// bash required to run schema scripts on linux (cannot be standard sh)
 				xjcCmd = "bash "+xjcCmd;
 				jxcCmd = "bash "+jxcCmd;
+                        } else if (platform.equals("solaris")) {
+				xjcCmd = "ksh "+xjcCmd;
+				jxcCmd = "ksh "+jxcCmd;
                         }
 			
 			fileContent += "concurrency " + concurrencyString + ";\n";


### PR DESCRIPTION
Equivalent to https://github.com/adoptium/aqa-systemtest/pull/439/files for Solaris to enable TCK execution

Signed-off-by: Stewart X Addison <sxa@redhat.com>