### PR TITLE
Change testhost1name to be trss rather than jckservices

### DIFF
--- a/openjdk.test.jck/config/default/jcktest.properties
+++ b/openjdk.test.jck/config/default/jcktest.properties
@@ -7,8 +7,8 @@
 # The tests default to using 'default' as the config name.  If another name is used it must be
 # supplied to the test at run time - see openjdk.test.jck/docs/README.md for more details.
 
-testhost1name=jckservices.adoptium.net
-testhost1ip=40.121.206.1
+testhost1name=trss.adoptium.net
+testhost1ip=54.78.186.5
 testhost2name=hg.openjdk.java.net
 testhost2ip=137.254.56.63
 httpurl=http://openjdk.java.net/index.html


### PR DESCRIPTION
On windows, we have been fudging the DNS records to use an internal IP which has resulted in the testhostname tests failing.

This PR switches the host to be trss instead