### PR TITLE
Avoid loading classes from RMI Activation package from JDK17+

### DIFF
--- a/openjdk.test.classloading/src/test.classloading/net/adoptopenjdk/test/classloading/ClassHog.java
+++ b/openjdk.test.classloading/src/test.classloading/net/adoptopenjdk/test/classloading/ClassHog.java
@@ -68,6 +68,13 @@ public class ClassHog
 							continue;
 						}
 					}
+					
+					if (javaVersion >= 17) {
+						// The RMI Activation mechanism has been deprecated from jdk 17
+						if ( classToLoad.startsWith("java.rmi.activation") ) {
+							continue;
+						}
+					}
 					// use the class loader to get the Class class that represents the class on the current line
 					c = Class.forName (classToLoad);
 					cnt++;

--- a/openjdk.test.classloading/src/test.classloading/net/adoptopenjdk/test/classloading/ClassMapHog.java
+++ b/openjdk.test.classloading/src/test.classloading/net/adoptopenjdk/test/classloading/ClassMapHog.java
@@ -111,6 +111,13 @@ public class ClassMapHog
 								continue;
 							}
 						}
+						
+						if (javaVersion >= 17) {
+							// The RMI Activation mechanism has been deprecated from jdk 17
+							if ( classToLoad.startsWith("java.rmi.activation") ) {
+								continue;
+							}
+						}
 					
 						// get the class loader to load the current class
 						// Class is the class that represents a classes 'blueprint'


### PR DESCRIPTION

Resolves https://github.com/eclipse-openj9/openj9/issues/13325

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>