### PR TITLE
Add support for compiling natives on macOS arm64

### DIFF
--- a/openjdk.test.jck/src/native/makefile
+++ b/openjdk.test.jck/src/native/makefile
@@ -34,6 +34,11 @@ endif
 
 ifneq (,$(findstring darwin,$(OS)))
 	OS:=osx
+	ARCH:=$(shell sysctl -n machdep.cpu.brand_string)
+	# Detected M1 chip
+	ifeq ($(ARCH),Apple M1)
+		ARCH:=arm64
+	endif
 endif
 
 ifeq ($(OS),os/390)

--- a/openjdk.test.jck/src/native/makefile
+++ b/openjdk.test.jck/src/native/makefile
@@ -34,8 +34,8 @@ endif
 
 ifneq (,$(findstring darwin,$(OS)))
 	OS:=osx
+	# Detect a M1 processor. Needed because uname -m doesn't work when the shell runs in x86_64 emulation
 	ARCH:=$(shell sysctl -n machdep.cpu.brand_string)
-	# Detected M1 chip
 	ifeq ($(ARCH),Apple M1)
 		ARCH:=arm64
 	endif

--- a/openjdk.test.jck/src/native/makefile
+++ b/openjdk.test.jck/src/native/makefile
@@ -26,6 +26,7 @@
 # Figure out current platform
 ###
 OS:=$(shell uname -s | tr "[:upper:]" "[:lower:]")
+ARCH:=$(shell uname -m | tr "[:upper:]" "[:lower:]")
 
 ifneq (,$(findstring cygwin,$(OS)))
 	OS:=win
@@ -145,7 +146,11 @@ LDFLAGS=-shared
 
 ifeq ($(OS),osx)
 	CC=gcc
-	CFLAGS=-fPIC -I$(OSX_PATH) -I$(SRC_PATH)
+	ifeq ($(ARCH),arm64)
+		CFLAGS=-arch arm64 -fPIC -I$(OSX_PATH) -I$(SRC_PATH)
+	else
+		CFLAGS=-fPIC -I$(OSX_PATH) -I$(SRC_PATH)
+	endif
 	LDFLAGS=-shared
 endif
 

--- a/openjdk.test.jck/src/native/makefile
+++ b/openjdk.test.jck/src/native/makefile
@@ -45,6 +45,7 @@ ifneq (,$(findstring win,$(OS)))
 endif
 
 $(info OS is $(OS))
+$(info ARCH is $(ARCH))
 
 ifeq ($(OS),win)
 	DESTDIR=$(OUTDIR)\$(OS)


### PR DESCRIPTION
fixes failing `vm_jni` tests on macOS arm64. The `-arch arm64` flag is needed because the shell runs in x86_64 emulation