### PR TITLE
enable headless tck option for alpine-linux

### DIFF
--- a/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
+++ b/openjdk.test.jck/src/test.jck/net/adoptopenjdk/stf/Jck.java
@@ -624,6 +624,8 @@ public class Jck implements StfPluginInterface {
 				if (platform.equals("zos")) {
 					fileContent += "set jck.env.testPlatform.headless Yes" + ";\n";
 					fileContent += "set jck.env.runtime.testExecute.otherEnvVars LIBPATH=/usr/lpp/tcpip/X11R66/lib" + ";\n";
+				} else if (platform.equals("alpine-linux") ) {
+					fileContent += "set jck.env.testPlatform.headless Yes" + ";\n";	
 				}
 				else {
 					if ( !platform.equals("win32") ) {


### PR DESCRIPTION
We need to find a way to only set this option for Temurin builds. IBM and others may want to test a headfull alpine binary