### PR TITLE
Add synchronization to Person class

### DIFF
--- a/openjdk.test.lambdasAndStreams/src/test.lambda/net/adoptopenjdk/test/lambda/support/Person.java
+++ b/openjdk.test.lambdasAndStreams/src/test.lambda/net/adoptopenjdk/test/lambda/support/Person.java
@@ -86,7 +86,9 @@ public class Person extends Animal implements Serializable {
 		this.name = new NameDetails(firstName, surname);
 		this.age = age;
 		
-		this.serialNumber = nextSerialNumber++;
+		synchronized (Person.class) {
+			this.serialNumber = nextSerialNumber++;
+		}
 	}
 	
 	public Title getTitle() {


### PR DESCRIPTION
A lock on the Person class must now be acquired before incrementing
nextSerialNumber. This prevents conflicting updates when multiple threads try
to increment it at the same time.

Signed-off-by: jimmyk <jimmyk@ca.ibm.com>