### PR TITLE
Exclude nio from zos

### DIFF
--- a/openjdk.test.load/config/inventories/mix/mix-more-zos.xml
+++ b/openjdk.test.load/config/inventories/mix/mix-more-zos.xml
@@ -1,0 +1,11 @@
+<!-- 
+  This is a minimal inventory intended for tests which just want to be able
+  to generate a load which can be used for testing other capabilities alongside.
+-->
+
+<inventory>
+	<include inventory="/openjdk.test.load/config/inventories/math/bigdecimal.xml"/>
+	<include inventory="/openjdk.test.load/config/inventories/mauve/mauve_multiThread.xml"/>
+	<include inventory="/openjdk.test.load/config/inventories/lang/lang.xml"/>
+	<include inventory="/openjdk.test.load/config/inventories/concurrent/concurrent.xml"/>
+</inventory>

--- a/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MixedLoadTest.java
+++ b/openjdk.test.load/src/test.load/net/adoptopenjdk/stf/MixedLoadTest.java
@@ -17,6 +17,7 @@ package net.adoptopenjdk.stf;
 import net.adoptopenjdk.loadTest.InventoryData;
 import net.adoptopenjdk.loadTest.TimeBasedLoadTest;
 import net.adoptopenjdk.stf.environment.FileRef;
+import net.adoptopenjdk.stf.environment.PlatformFinder;
 import net.adoptopenjdk.stf.extensions.core.StfCoreExtension;
 import net.adoptopenjdk.stf.extensions.core.StfCoreExtension.Echo;
 import net.adoptopenjdk.stf.processes.ExpectedOutcome;
@@ -42,8 +43,14 @@ public class MixedLoadTest extends TimeBasedLoadTest {
 		if (!fileSystemJar.asJavaFile().exists()) {
 			throw new StfException("The filesystem.jar does not exist: " + fileSystemJar.getSpec());
 		}
-
+		
 		String inventoryFile = "/openjdk.test.load/config/inventories/mix/mix-more.xml";
+		
+		// When on z/OS, use a load mix that does not contain nio load tests 
+		if ( PlatformFinder.isZOS() ) {
+			inventoryFile = "/openjdk.test.load/config/inventories/mix/mix-more-zos.xml";
+		}
+		
 		int totalTests = InventoryData.getNumberOfTests(test, inventoryFile);
 		int cpuCount = Runtime.getRuntime().availableProcessors();
 


### PR DESCRIPTION
In order to avoid running into encoding issues that the generated class files of NIO load test pose (see openj9-openjdk-jdk11-zos/issues/342 for details), while on z/OS we will run a mixed load test that does not include Nio load tests. 

This PR creates a new inventory file to be used by MixedLoadTest while on z/OS which essentially uses the same loads as before minus NIO tests. 

Signed-off-by: Mesbah-Alam <Mesbah_Alam@ca.ibm.com>  