### PR TITLE
Reintroducing StringIndexOutOfBoundsException as the bug is fixed

### DIFF
--- a/openjdk.test.load/config/inventories/mauve/mauve_all_exclude.xml
+++ b/openjdk.test.load/config/inventories/mauve/mauve_all_exclude.xml
@@ -1,13 +1,7 @@
 <inventory>
 	<!-- Fails on JDK 18. Excluded due to https://github.com/eclipse-openj9/openj9/issues/14168 -->
 	<mauve class="gnu.testlet.java.net.HttpURLConnection.requestPropertiesTest"/>
-	<!-- Fails on JDK11 and up if run many times.
-		 Issue: https://github.com/adoptium/aqa-tests/issues/2293
-		 Note: The issue has been fixed upstream, and has been backported.
-		 We're waiting for the fix to move from JDKx-dev forks into JDKx.
-	-->
-	<mauve class="gnu.testlet.java.lang.StringIndexOutOfBoundsException.constructor"/>
-	
+
 	<!-- Excluded as invalid test. Ref: https://github.com/eclipse/openj9/issues/7020 -->
 	<mauve class="gnu.testlet.java.io.InputStreamReader.utf8"/>
 	<!-- Disabled as the following sub-tests are incompatible with jdk16 on HotSpot -->

--- a/openjdk.test.load/config/inventories/mauve/mauve_multiThread_exclude.xml
+++ b/openjdk.test.load/config/inventories/mauve/mauve_multiThread_exclude.xml
@@ -1,11 +1,4 @@
 <inventory>
-	<!-- Fails on JDK11 and up if run many times.
-		 Issue: https://github.com/adoptium/aqa-tests/issues/2293
-		 Note: The issue has been fixed upstream, and has been backported.
-		 We're waiting for the fix to move from JDKx-dev forks into JDKx.
-	-->
-	<mauve class="gnu.testlet.java.lang.StringIndexOutOfBoundsException.constructor"/>
-	
 	<!-- Disabled as the following sub-tests are incompatible with jdk16 on HotSpot -->
 	<!-- Details in issue: https://github.com/adoptium/aqa-tests/issues/2150 -->
 	<mauve class="gnu.testlet.java.util.HashMap.AcuniaHashMapTest"/>


### PR DESCRIPTION
This test should now run and pass on all JDK versions it's meant to
run against, as the upstream OpenJDK bug (JDK-8267773) is resolved
and backported, with the code fully propagated.

Signed-off-by: Adam Farley <adfarley@redhat.com>