### PR TITLE
Exclude isAnnotationPresent from mauve load for jdk20

### DIFF
--- a/openjdk.test.load/config/inventories/mauve/mauve_all_exclude.xml
+++ b/openjdk.test.load/config/inventories/mauve/mauve_all_exclude.xml
@@ -1,4 +1,8 @@
 <inventory>
+	
+	<!-- Fails on JDK 20. Excluded due to https://github.com/eclipse-openj9/openj9-systemtest/issues/147 -->
+	<mauve class="gnu.testlet.java.lang.ThreadDeath.classInfo.isAnnotationPresent"/>
+	
 	<!-- Fails on JDK 18. Excluded due to https://github.com/eclipse-openj9/openj9/issues/14168 -->
 	<mauve class="gnu.testlet.java.net.HttpURLConnection.requestPropertiesTest"/>
 


### PR DESCRIPTION
- Exclude `gnu.testlet.java.lang.ThreadDeath.classInfo.isAnnotationPresent ` from Mauve load as it doesn't work on JDK-20. 
- Resolves : https://github.com/eclipse-openj9/openj9-systemtest/issues/147

FYI @Peter_Shipton@ca.ibm.com

Signed-off-by: Mesbah Alam <Mesbah_Alam@ca.ibm.com>