### PR TITLE
Exclude java.lang.Compiler from classloading test on JDK 21+

### DIFF
--- a/openjdk.test.classloading/src/test.classloading/net/adoptopenjdk/test/classloading/ClassHog.java
+++ b/openjdk.test.classloading/src/test.classloading/net/adoptopenjdk/test/classloading/ClassHog.java
@@ -51,27 +51,34 @@ public class ClassHog
 				try
 				{
 					// Mauve CORBA related tests have been removed from all Java releases 
-					if ( classToLoad.startsWith("org.omg") ) {
+					if (classToLoad.startsWith("org.omg") ) {
 						continue; 
 					}
 					
 					if (javaVersion >= 11) {
 						// javax.transaction has been removed from Java 11
-						if ( classToLoad.startsWith("javax.transaction") ) {
+						if (classToLoad.startsWith("javax.transaction") ) {
 							continue;
 						}
 					}
 					
 					if (javaVersion >= 14) {
 						// java.security.acl package has been removed from jdk 14
-						if ( classToLoad.startsWith("java.security.acl") ) {
+						if (classToLoad.startsWith("java.security.acl") ) {
 							continue;
 						}
 					}
 					
 					if (javaVersion >= 17) {
 						// The RMI Activation mechanism has been deprecated from jdk 17
-						if ( classToLoad.startsWith("java.rmi.activation") ) {
+						if (classToLoad.startsWith("java.rmi.activation") ) {
+							continue;
+						}
+					}
+
+					if (javaVersion >= 21) {
+						// The java.lang.Compiler class has been removed from jdk 21
+						if (classToLoad.startsWith("java.lang.Compiler") ) {
 							continue;
 						}
 					}

--- a/openjdk.test.classloading/src/test.classloading/net/adoptopenjdk/test/classloading/ClassHog.java
+++ b/openjdk.test.classloading/src/test.classloading/net/adoptopenjdk/test/classloading/ClassHog.java
@@ -51,27 +51,27 @@ public class ClassHog
 				try
 				{
 					// Mauve CORBA related tests have been removed from all Java releases 
-					if (classToLoad.startsWith("org.omg") ) {
+					if (classToLoad.startsWith("org.omg")) {
 						continue; 
 					}
 					
 					if (javaVersion >= 11) {
 						// javax.transaction has been removed from Java 11
-						if (classToLoad.startsWith("javax.transaction") ) {
+						if (classToLoad.startsWith("javax.transaction")) {
 							continue;
 						}
 					}
 					
 					if (javaVersion >= 14) {
 						// java.security.acl package has been removed from jdk 14
-						if (classToLoad.startsWith("java.security.acl") ) {
+						if (classToLoad.startsWith("java.security.acl")) {
 							continue;
 						}
 					}
 					
 					if (javaVersion >= 17) {
 						// The RMI Activation mechanism has been deprecated from jdk 17
-						if (classToLoad.startsWith("java.rmi.activation") ) {
+						if (classToLoad.startsWith("java.rmi.activation")) {
 							continue;
 						}
 					}

--- a/openjdk.test.classloading/src/test.classloading/net/adoptopenjdk/test/classloading/ClassMapHog.java
+++ b/openjdk.test.classloading/src/test.classloading/net/adoptopenjdk/test/classloading/ClassMapHog.java
@@ -95,12 +95,12 @@ public class ClassMapHog
 					try
 					{
 						// Mauve CORBA related tests have been removed from all Java releases 
-						if (classToLoad.startsWith("org.omg") ) {
+						if (classToLoad.startsWith("org.omg")) {
 							continue; 
 						}
 						if (javaVersion >= 11) {
 							// javax.transaction and CORBA has been removed from Java 11
-							if (classToLoad.startsWith("javax.transaction") ) {
+							if (classToLoad.startsWith("javax.transaction")) {
 								continue;
 							}
 						}

--- a/openjdk.test.classloading/src/test.classloading/net/adoptopenjdk/test/classloading/ClassMapHog.java
+++ b/openjdk.test.classloading/src/test.classloading/net/adoptopenjdk/test/classloading/ClassMapHog.java
@@ -95,30 +95,36 @@ public class ClassMapHog
 					try
 					{
 						// Mauve CORBA related tests have been removed from all Java releases 
-						if ( classToLoad.startsWith("org.omg") ) {
+						if (classToLoad.startsWith("org.omg") ) {
 							continue; 
 						}
 						if (javaVersion >= 11) {
 							// javax.transaction and CORBA has been removed from Java 11
-							if ( classToLoad.startsWith("javax.transaction") ) {
+							if (classToLoad.startsWith("javax.transaction") ) {
 								continue;
 							}
 						}
 						
 						if (javaVersion >= 14) {
 							// java.security.acl package has been removed from jdk 14
-							if ( classToLoad.startsWith("java.security.acl") ) {
+							if (classToLoad.startsWith("java.security.acl") ) {
 								continue;
 							}
 						}
 						
 						if (javaVersion >= 17) {
 							// The RMI Activation mechanism has been deprecated from jdk 17
-							if ( classToLoad.startsWith("java.rmi.activation") ) {
+							if (classToLoad.startsWith("java.rmi.activation") ) {
 								continue;
 							}
 						}
-					
+
+						if (javaVersion >= 21) {
+							// The java.lang.Compiler class has been removed from jdk 21
+							if (classToLoad.startsWith("java.lang.Compiler") ) {
+								continue;
+							}
+						}
 						// get the class loader to load the current class
 						// Class is the class that represents a classes 'blueprint'
 						c = Class.forName (classToLoad);


### PR DESCRIPTION
Fixes https://github.com/adoptium/aqa-tests/issues/4732

java.lang.Compiler was removed in JDK 21:
https://bugs.openjdk.org/browse/JDK-8205129
https://jdk.java.net/21/release-notes

Also has some spacing fixes nearby.