### PR TITLE
Update BigDecimal testing for jdk22+ behavior

### DIFF
--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite000.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite000.java
@@ -1064,6 +1064,11 @@ public class TestSuite000 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("35.23489932885906%", true, caught);
   }
   public void testItem_0143()
@@ -4134,6 +4139,11 @@ public class TestSuite000 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("76.1744966442953%", true, caught);
   }

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite003.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite003.java
@@ -1540,6 +1540,11 @@ public class TestSuite003 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("89.59731543624162%", true, caught);
   }
   public void testItem_0209()
@@ -1644,6 +1649,11 @@ public class TestSuite003 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("89.59731543624162%", true, caught);
   }
@@ -2096,6 +2106,11 @@ public class TestSuite003 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("89.93288590604027%", true, caught);
   }
@@ -3124,6 +3139,11 @@ public class TestSuite003 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("89.93288590604027%", true, caught);
   }

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite004.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite004.java
@@ -5196,6 +5196,11 @@ public class TestSuite004 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("89.93288590604027%", true, caught);
   }
   public void testItem_0745()
@@ -5336,6 +5341,11 @@ public class TestSuite004 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("89.93288590604027%", true, caught);
   }

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite008.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite008.java
@@ -3151,6 +3151,11 @@ public class TestSuite008 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("90.93959731543625%", true, caught);
   }
   public void testItem_0451()

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite009.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite009.java
@@ -6498,6 +6498,11 @@ public class TestSuite009 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.2751677852349%", true, caught);
   }
   public void testItem_0953()

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite010.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite010.java
@@ -1228,6 +1228,11 @@ public class TestSuite010 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.61073825503355%", true, caught);
   }
   public void testItem_0175()

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite011.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite011.java
@@ -3101,6 +3101,11 @@ public class TestSuite011 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.61073825503355%", true, caught);
   }
   public void testItem_0439()
@@ -5560,6 +5565,11 @@ public class TestSuite011 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("91.61073825503355%", true, caught);
   }

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite014.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite014.java
@@ -3299,6 +3299,11 @@ public class TestSuite014 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.61073825503355%", true, caught);
   }
   public void testItem_0464()
@@ -3611,6 +3616,11 @@ public class TestSuite014 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.61073825503355%", true, caught);
   }
   public void testItem_0503()
@@ -3790,6 +3800,11 @@ public class TestSuite014 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("91.61073825503355%", true, caught);
   }
@@ -4119,6 +4134,11 @@ public class TestSuite014 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("91.61073825503355%", true, caught);
   }
@@ -7033,6 +7053,11 @@ public class TestSuite014 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("91.61073825503355%", true, caught);
   }

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite015.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite015.java
@@ -1953,6 +1953,11 @@ public class TestSuite015 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.61073825503355%", true, caught);
   }
   public void testItem_0280()

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite019.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite019.java
@@ -3190,7 +3190,12 @@ public class TestSuite019 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
-    Assert.assertEquals("91.94630872483222%", true, caught);
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
+   Assert.assertEquals("91.94630872483222%", true, caught);
   }
   public void testItem_0461()
   {

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite020.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite020.java
@@ -284,6 +284,11 @@ public class TestSuite020 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
   public void testItem_0035()
@@ -322,6 +327,11 @@ public class TestSuite020 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite021.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite021.java
@@ -4392,6 +4392,11 @@ public class TestSuite021 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
   public void testItem_0617()

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite024.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite024.java
@@ -3532,6 +3532,11 @@ public class TestSuite024 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
   public void testItem_0514()
@@ -3949,6 +3954,11 @@ public class TestSuite024 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
@@ -4516,6 +4526,11 @@ public class TestSuite024 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite026.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite026.java
@@ -290,6 +290,11 @@ public class TestSuite026 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
   public void testItem_0036()

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite028.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite028.java
@@ -3864,6 +3864,11 @@ public class TestSuite028 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
   public void testItem_0564()
@@ -4115,6 +4120,11 @@ public class TestSuite028 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
@@ -4711,6 +4721,11 @@ public class TestSuite028 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
@@ -5748,6 +5763,11 @@ public class TestSuite028 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite029.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite029.java
@@ -4147,6 +4147,11 @@ public class TestSuite029 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
   public void testItem_0588()

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite030.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite030.java
@@ -1362,6 +1362,11 @@ public class TestSuite030 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
 //  public void testItem_0193()

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite031.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite031.java
@@ -5314,6 +5314,11 @@ public class TestSuite031 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
   public void testItem_0776()

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite032.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite032.java
@@ -4596,6 +4596,11 @@ public class TestSuite032 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
   public void testItem_0656()

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite035.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite035.java
@@ -814,6 +814,11 @@ public class TestSuite035 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
 //  public void testItem_0107()
@@ -5321,6 +5326,11 @@ public class TestSuite035 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite036.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite036.java
@@ -2364,6 +2364,11 @@ public class TestSuite036 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
   public void testItem_0340()
@@ -4113,6 +4118,11 @@ public class TestSuite036 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
@@ -6702,6 +6712,11 @@ public class TestSuite036 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite039.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite039.java
@@ -2494,6 +2494,11 @@ public class TestSuite039 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
   public void testItem_0360()

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite040.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite040.java
@@ -3325,6 +3325,11 @@ public class TestSuite040 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
   public void testItem_0491()
@@ -3391,6 +3396,11 @@ public class TestSuite040 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
@@ -4231,6 +4241,11 @@ public class TestSuite040 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite041.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite041.java
@@ -3807,6 +3807,11 @@ public class TestSuite041 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
 //  public void testItem_0569()
@@ -5832,6 +5837,11 @@ public class TestSuite041 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite043.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite043.java
@@ -670,6 +670,11 @@ public class TestSuite043 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
   public void testItem_0089()
@@ -1531,6 +1536,11 @@ public class TestSuite043 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite047.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite047.java
@@ -495,6 +495,11 @@ public class TestSuite047 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
   public void testItem_0062()
@@ -3511,6 +3516,11 @@ public class TestSuite047 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite049.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite049.java
@@ -635,6 +635,11 @@ public class TestSuite049 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
   public void testItem_0082()
@@ -722,6 +727,11 @@ public class TestSuite049 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
@@ -1293,6 +1303,11 @@ public class TestSuite049 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite053.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite053.java
@@ -3898,6 +3898,11 @@ public class TestSuite053 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
   public void testItem_0588()

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite054.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite054.java
@@ -2072,6 +2072,11 @@ public class TestSuite054 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
   public void testItem_0286()
@@ -6262,6 +6267,11 @@ public class TestSuite054 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite055.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite055.java
@@ -258,6 +258,11 @@ public class TestSuite055 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
   public void testItem_0030()
@@ -4123,6 +4128,11 @@ public class TestSuite055 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
   public void testItem_0580()
@@ -6685,6 +6695,11 @@ public class TestSuite055 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite056.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite056.java
@@ -4886,6 +4886,11 @@ public class TestSuite056 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
   public void testItem_0707()

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite058.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite058.java
@@ -656,6 +656,11 @@ public class TestSuite058 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
   @SuppressWarnings("unlikely-arg-type")

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite060.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite060.java
@@ -869,6 +869,11 @@ public class TestSuite060 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
   public void testItem_0109()
@@ -3753,6 +3758,11 @@ public class TestSuite060 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
   public void testItem_0522()
@@ -6154,6 +6164,11 @@ public class TestSuite060 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
   public void testItem_0878()
@@ -6642,6 +6657,11 @@ public class TestSuite060 extends TestCase
     }
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
+    }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
     }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }

--- a/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite061.java
+++ b/openjdk.test.math/src/test.math/net/adoptopenjdk/test/bigdecimal/TestSuite061.java
@@ -6079,6 +6079,11 @@ public class TestSuite061 extends TestCase
     catch (java.lang.NegativeArraySizeException e) {
       caught = true;
     }
+    catch (java.lang.OutOfMemoryError e) {
+    	if (e.getMessage().contains("too large")) {
+    		caught = true;
+    	}
+    }
     Assert.assertEquals("91.94630872483222%", true, caught);
   }
   public void testItem_0882()


### PR DESCRIPTION
Calling toPlainString() on a BigDecimal with a large negative exponent throws OutOfMemoryError("too large to fit in a String") rather than NegativeArraySizeException.

Fixes https://github.com/adoptium/aqa-systemtest/issues/486

Tested via https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/3297 on the latest Adoptium Hotspot jdk22 ea build (+35), which passed.
```
15:09:26  openjdk version "22-beta" 2024-03-19
15:09:26  OpenJDK Runtime Environment Temurin-22+35-202402100012 (build 22-beta+35-ea)
15:09:26  OpenJDK 64-Bit Server VM Temurin-22+35-202402100012 (build 22-beta+35-ea, mixed mode)
```