### PR TITLE
Change xlc to be found on the PATH and not a specific version

### DIFF
--- a/openjdk.test.jck/src/native/makefile
+++ b/openjdk.test.jck/src/native/makefile
@@ -167,7 +167,7 @@ ifeq ($(OS),sunos)
 endif
 
 ifeq ($(OS),aix)
-	CC=/opt/IBM/xlC/13.1.3/bin/xlc
+	CC=xlc
 	CFLAGS=-qstaticinline -q$(BitMode) -I$(UNIX_PATH) -I$(OSX_PATH) -I$(SRC_PATH)
 	LDFLAGS=-G -q$(BitMode)
 endif


### PR DESCRIPTION
- Fixes adoptium/aqa-systemtest#491