### PR TITLE
Exclude Mauve tests that use SecurityManager for JDK24

### DIFF
--- a/openjdk.test.load/config/inventories/mauve/mauve_all_exclude.xml
+++ b/openjdk.test.load/config/inventories/mauve/mauve_all_exclude.xml
@@ -2047,4 +2047,9 @@
 	<mauve class="gnu.testlet.java.util.IllegalFormatWidthException.classInfo.getDeclaredMethods"/>
 	<mauve class="gnu.testlet.java.util.IllegalFormatWidthException.classInfo.getFields"/>
 	<mauve class="gnu.testlet.java.util.IllegalFormatWidthException.classInfo.getMethods"/>
+
+	<!-- Tests using the SecurityManager will fail in JDK 24+. -->
+	<mauve class="gnu.testlet.java.security.ProtectionDomain.Implies"/>
+	<mauve class="gnu.testlet.java.util.logging.Logger.getAnonymousLogger"/>
+	<mauve class="gnu.testlet.java.util.logging.Logger.getName"/>
 </inventory>

--- a/openjdk.test.load/config/inventories/mauve/mauve_multiThread_exclude.xml
+++ b/openjdk.test.load/config/inventories/mauve/mauve_multiThread_exclude.xml
@@ -43,8 +43,10 @@
 	Issue ref: https://github.com/adoptium/aqa-systemtest/issues/298 -->
 	<mauve class="gnu.testlet.java.util.Calendar.getInstance"/>
 	<mauve class="gnu.testlet.java.util.Date.range"/>
-	<!-- Exclude tests that install SecurityManager 
+	<!-- Tests using the SecurityManager will fail in JDK 24+.
+	The Logger tests were also excluded previously due to 
 	Issue Ref: https://github.com/adoptium/aqa-systemtest/issues/284-->
+	<mauve class="gnu.testlet.java.security.ProtectionDomain.Implies"/>
 	<mauve class="gnu.testlet.java.util.logging.Logger.getAnonymousLogger"/>
 	<mauve class="gnu.testlet.java.util.logging.Logger.getName"/>
 	<!-- Fails on jdk12 hotspot with: 


### PR DESCRIPTION
The SecurityManager is removed in JDK 24. Exclude Mauve tests that are failing due to illegal use of the security manager.